### PR TITLE
add instructions to migrate external links migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,7 @@ Install dependencies:
 
     bundle install
 
-Copy migrations of pageflow-external-links into your project and migrate the database:
-
-    bundle exec rake pageflow_external_links:install:migrations
-    bundle exec rake db:migrate
+Then follow the installation instructions for the [pageflow-external-links](https://github.com/codevise/pageflow-external-links) gem.
 
 Restart the application server and enable the corresponding page type
 feature.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ pages and inline audio players.
 Add this line to your application's `Gemfile`:
 
     gem 'pageflow-linkmap-page'
+    gem 'pageflow-external-links' # needed to copy the migration contained within
 
 Register the page type inside the configure block in `config/initializers/pageflow.rb`
 
@@ -43,6 +44,11 @@ Import default theme additions:
 Install dependencies:
 
     bundle install
+
+Copy migrations of pageflow-external-links into your project and migrate the database:
+
+    bundle exec rake pageflow_external_links:install:migrations
+    bundle exec rake db:migrate
 
 Restart the application server and enable the corresponding page type
 feature.


### PR DESCRIPTION
These are needed in order for this plugin to function.

Fixes #2 