### PR TITLE
Use info box title as title for text only areas

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
@@ -26,8 +26,13 @@ pageflow.linkmapPage.Area = Backbone.Model.extend({
   },
 
   title: function() {
-    var target = this.target();
-    return target ? target.title() : null;
+    if (this.get('target_type') === 'text_only') {
+      return this.get('link_title');
+    }
+    else {
+      var target = this.target();
+      return target ? target.title() : null;
+    }
   },
 
   thumbnailFile: function() {


### PR DESCRIPTION
Prevent text areas to be displayed as "(Unknown)" in editor area list.