### PR TITLE
Disable links in overlay boxes

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/editor/views/edit_area_view.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/views/edit_area_view.js
@@ -76,7 +76,10 @@ pageflow.linkmapPage.EditAreaView = Backbone.Marionette.Layout.extend({
       });
 
       this.input('link_title', pageflow.TextInputView);
-      this.input('link_description', pageflow.TextAreaInputView, {size: 'short'});
+      this.input('link_description', pageflow.TextAreaInputView, {
+        size: 'short',
+        disableLinks: true
+      });
     });
 
     configurationEditor.tab('appearance', function() {


### PR DESCRIPTION
Not accessible with mouse anyway since overlays close when hotspot is left.