### PR TITLE
Prevent scrolling via mousemove on mobile platform

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_lookaround.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_lookaround.js
@@ -61,13 +61,15 @@
         that.initialGamma = null;
       });
 
-      this.element.on('mousemove', function(e) {
-        var containerWidth = that.element.width();
-        var containerHeight = that.element.height();
+      if (!pageflow.browser.has('mobile platform')) {
+        this.element.on('mousemove', function(e) {
+          var containerWidth = that.element.width();
+          var containerHeight = that.element.height();
 
-        that.scrollStrategyX.updateMouse(e.pageX / containerWidth);
-        that.scrollStrategyY.updateMouse(e.pageY / containerHeight);
-      });
+          that.scrollStrategyX.updateMouse(e.pageX / containerWidth);
+          that.scrollStrategyY.updateMouse(e.pageY / containerHeight);
+        });
+      }
     },
 
     enable: function() {


### PR DESCRIPTION
Do not start scrolling when tapping in page margin.