### PR TITLE
Require Pageflow 12

### DIFF
--- a/pageflow-linkmap-page.gemspec
+++ b/pageflow-linkmap-page.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'pageflow', '~> 0.10'
+  spec.add_runtime_dependency 'pageflow', ['>= 0.10', '< 13']
   spec.add_runtime_dependency 'pageflow-external-links', '~> 0.3'
 
   # Using translations from rails locales in javascript code.


### PR DESCRIPTION
`0.12` will be released as `12.0`.