### PR TITLE
Fix hover video variant in published entry

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/area_redraw.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/area_redraw.js
@@ -6,7 +6,12 @@ $.fn.linkmapAreaRedraw = function(options) {
     var mask = options.masks && options.masks.findByPermaId(area.attr('data-mask-id'));
     area.data('mask', mask || null);
 
-    var canvas = area.find(options.target)[0];
+    var canvas = area.find('canvas').filter(options.target)[0];
+
+    if (!canvas) {
+      return;
+    }
+
     var context = canvas.getContext('2d');
 
     if (options.image) {


### PR DESCRIPTION
For the hover video variant, there is no canvas which needs to be
redrawn. Check whether canvas exists first.