### PR TITLE
Make mask image url template generation more robust

### DIFF
--- a/app/helpers/pageflow/linkmap_page/areas_helper.rb
+++ b/app/helpers/pageflow/linkmap_page/areas_helper.rb
@@ -8,7 +8,7 @@ module Pageflow
         visited_image_file = Pageflow::ImageFile.find_by_id(configuration['visited_image_id'])
 
         mask_sprite_url_template = MaskSprite.new(id: 1, attachment_file_name: 'data').attachment.url
-          .gsub(%r'(\d{3}/)+', ':id_partition/')
+          .gsub(%r'/(\d{3}/)+', '/:id_partition/')
 
         render('pageflow/linkmap_page/areas/div',
                entry: entry,

--- a/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
+++ b/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
@@ -51,6 +51,16 @@ module Pageflow
 
           expect(html).not_to have_selector('a[data-mask-id]')
         end
+
+        it 'renders attribute with url template for mask sprite' do
+          entry = create(:entry)
+          configuration = {}
+
+          html = helper.linkmap_areas_div(entry, configuration)
+
+          url_matcher = 'attachments/:id_partition/original'
+          expect(html).to have_selector("div[data-mask-sprite-url-template*='#{url_matcher}']")
+        end
       end
 
       describe '#linkmap_area' do


### PR DESCRIPTION
Only replace digit-only segments with `:id_partition` placeholder.