### PR TITLE
Do not show load indicator for external link opening new tab

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_panorama.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_panorama.js
@@ -90,7 +90,9 @@
             area.addClass('active');
           }
 
-          if (!area.hasClass('dynamic_marker') && area.hasClass('external_site_area')) {
+          if (!area.hasClass('dynamic_marker') &&
+              area.hasClass('external_site_area') &&
+              area.hasClass('target_self')) {
             displayExternalLinkLoadingIndicator(event.originalEvent);
           }
         });


### PR DESCRIPTION
Only needed if opened in same tab.