### PR TITLE
Enforce min size when dragging new hotspot

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_masks_preview_embedded_view.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_masks_preview_embedded_view.js
@@ -66,6 +66,14 @@ pageflow.linkmapPage.AreaMasksPreviewEmbeddedView = Backbone.Marionette.ItemView
       var width = Math.abs(mouseUpEvent.offsetX - dragStartOffset.x);
       var height = Math.abs(mouseUpEvent.offsetY - dragStartOffset.y);
 
+      if (width < 10) {
+        width = 50;
+      }
+
+      if (height < 10) {
+        height = 50;
+      }
+
       view.selection.deferred.resolve({
         left: left / view.$el.width() * 100,
         top: top / view.$el.height() * 100,


### PR DESCRIPTION
Prevent creating too small hotspots when clicking instead of
dragging. Small hotspots can trigger unwanted scaling in mobile
layout.

REDMINE-15900