### PR TITLE
Adapt to Pageflow 13

### DIFF
--- a/lib/pageflow/linkmap_page/engine.rb
+++ b/lib/pageflow/linkmap_page/engine.rb
@@ -14,6 +14,10 @@ module Pageflow
         g.assets false
         g.helper false
       end
+
+      initializer 'pageflow_linkmap_page.paperclip' do
+        Paperclip::DataUriAdapter.register
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,6 @@
 ENV['RAILS_ENV'] ||= 'test'
 ENV['PAGEFLOW_PLUGIN_ENGINE'] = 'pageflow_linkmap_page'
 
-require 'factory_bot_rails'
-
 require 'pageflow/support'
 Pageflow::Dummy.setup
 

--- a/spec/support/config/factory_bot.rb
+++ b/spec/support/config/factory_bot.rb
@@ -1,3 +1,5 @@
+require 'factory_bot_rails'
+
 RSpec.configure do |config|
   # Allow to use build and create methods without FactoryBot prefix.
   config.include FactoryBot::Syntax::Methods


### PR DESCRIPTION
* Let `pageflow-support` require `factory_bot` to prevent loading
  models before Paperclip test env setup has been applied.

* Register Paperclip IO data uri adapter which is now opt-in.