### PR TITLE
Fallback to muted autoplay

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/page_type.js
+++ b/app/assets/javascript/pageflow/linkmap_page/page_type.js
@@ -121,9 +121,11 @@ pageflow.pageType.register('linkmap_page', _.extend({
       });
     });
 
-    pageflow.events.on('background_media:unmute', function() {
-      videoPlayer.muted(false);
-    });
+    if (pageflow.browser.has('autoplay support')) {
+      pageflow.events.on('background_media:unmute', function() {
+        videoPlayer.muted(false);
+      });
+    }
 
     wrapper.data('videoPlayer', this.videoPlayer);
   },
@@ -325,7 +327,8 @@ pageflow.pageType.register('linkmap_page', _.extend({
 
     this.videoPlayer.ensureCreated();
 
-    if (pageflow.backgroundMedia && pageflow.backgroundMedia.muted) {
+    if ((pageflow.backgroundMedia && pageflow.backgroundMedia.muted) ||
+        !pageflow.browser.has('autoplay support')) {
       this.videoPlayer.muted(true);
     }
 

--- a/app/assets/javascript/pageflow/linkmap_page/page_type.js
+++ b/app/assets/javascript/pageflow/linkmap_page/page_type.js
@@ -107,11 +107,22 @@ pageflow.pageType.register('linkmap_page', _.extend({
       .attr('data-width', template.data('videoWidth'))
       .attr('data-height', template.data('videoHeight'));
 
-    this.videoPlayer = new pageflow.VideoPlayer.Lazy(template, {
+    var videoPlayer = this.videoPlayer = new pageflow.VideoPlayer.Lazy(template, {
       volumeFading: true,
+      fallbackToMutedAutoplay: true,
 
       width: '100%',
       height: '100%'
+    });
+
+    videoPlayer.ready(function() {
+      videoPlayer.on('playmuted', function() {
+        pageflow.backgroundMedia.mute();
+      });
+    });
+
+    pageflow.events.on('background_media:unmute', function() {
+      videoPlayer.muted(false);
     });
 
     wrapper.data('videoPlayer', this.videoPlayer);
@@ -307,6 +318,10 @@ pageflow.pageType.register('linkmap_page', _.extend({
     var that = this;
 
     this.videoPlayer.ensureCreated();
+
+    if (pageflow.backgroundMedia && pageflow.backgroundMedia.muted) {
+      this.videoPlayer.muted(true);
+    }
 
     this.prebufferingPromise = this.videoPlayer.prebuffer().then(function() {
       if (configuration.background_type === 'video') {

--- a/app/assets/javascript/pageflow/linkmap_page/page_type.js
+++ b/app/assets/javascript/pageflow/linkmap_page/page_type.js
@@ -158,6 +158,12 @@ pageflow.pageType.register('linkmap_page', _.extend({
       hooks: pageflow.atmo.createMediaPlayerHooks(configuration)
     });
 
+    this.multiPlayer.on('play', function(options) {
+      if (pageflow.backgroundMedia) {
+        pageflow.backgroundMedia.unmute();
+      }
+    });
+
     pageElement.linkmapAudioPlayersController({
       player: this.multiPlayer
     });


### PR DESCRIPTION
Integrate with background media feature of Pageflow 12.3:

* Mute background media when video playback with sound fails

* Unmute video when background media is unmuted

* Unmute background media when playing an audio hotspot

* Play video muted on platforms that do not support autoplay

REDMINE-15771