### PR TITLE
Limit panorama min scaling

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_panorama/get_panorama_size.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_panorama/get_panorama_size.js
@@ -55,6 +55,6 @@ pageflow.linkmapPage.getPanoramaSize = (function() {
       smallestSize = Math.min(smallestSize, Math.min(width, height));
     });
 
-    return MIN_SCALING_SIZE / smallestSize;
+    return Math.min(1.5, MIN_SCALING_SIZE / Math.max(1, smallestSize));
   }
 }());


### PR DESCRIPTION
With arbitrarily small hot spots is does not make sense to scale the
panorama behond a certain point. Prevent dividing by zero.