### PR TITLE
Add compatibility to 1.5 changes

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
@@ -85,7 +85,8 @@ pageflow.linkmapPage.Area = Backbone.Model.extend({
   unsetMask: function() {
     this.set({
       marker: 'no_marker',
-      mask_perma_id: undefined
+      mask_perma_id: undefined,
+      color_map_component_id: undefined
     });
     this.trigger('change:dimensions');
   },
@@ -119,5 +120,17 @@ pageflow.linkmapPage.Area = Backbone.Model.extend({
 
   remove: function() {
     this.collection.remove(this);
+  },
+
+  get: function(attr) {
+    if (attr === 'mask_perma_id') {
+      var maskId = this.attributes['color_map_component_id'];
+      if(maskId === undefined) {
+        maskId = this.attributes['mask_perma_id'];
+      }
+      return maskId;
+    } else {
+      return this.attributes[attr];
+    }
   }
 });

--- a/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
@@ -123,12 +123,13 @@ pageflow.linkmapPage.Area = Backbone.Model.extend({
   },
 
   get: function(attr) {
-    if (attr === 'mask_perma_id') {
-      var maskId = this.attributes['color_map_component_id'];
-      if(maskId === undefined) {
-        maskId = this.attributes['mask_perma_id'];
+    if (attr === 'color_map_component_id') {
+      var colorMapComponentId = this.attributes['color_map_component_id'];
+      if(colorMapComponentId === undefined) {
+        // also try legacy mask_perma_id as fallback
+        colorMapComponentId = this.attributes['mask_perma_id'];
       }
-      return maskId;
+      return colorMapComponentId;
     } else {
       return this.attributes[attr];
     }

--- a/app/assets/javascript/pageflow/linkmap_page/editor/views/edit_area_view.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/views/edit_area_view.js
@@ -77,7 +77,7 @@ pageflow.linkmapPage.EditAreaView = Backbone.Marionette.Layout.extend({
 
     configurationEditor.tab('appearance', function() {
       this.input('marker', pageflow.SelectInputView, {values: pageflow.linkmapPage.markerOptions});
-      this.input('mask_perma_id', pageflow.linkmapPage.AreaMaskInputView, {
+      this.input('color_map_component_id', pageflow.linkmapPage.AreaMaskInputView, {
         visibleBinding: 'marker',
         visible: function(value) {
           return value !== 'dynamic_marker';

--- a/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_item_embedded_view.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_item_embedded_view.js
@@ -209,7 +209,7 @@ pageflow.linkmapPage.AreaItemEmbeddedView = Backbone.Marionette.ItemView.extend(
     var audioFileId = this.model.get('target_id');
     var colorMapComponent = this.getColorMapComponent();
 
-    this.$el.attr('data-mask-perma-id', colorMapComponent ? colorMapComponent.permaId : null);
+    this.$el.attr('data-color-map-component-id', colorMapComponent ? colorMapComponent.permaId : null);
     this.$el.attr('data-audio-file', audioFileId ? audioFileId + '.' + this.cid : '');
     this.$el.attr('data-target-type', this.model.get('target_type'));
     this.$el.attr('data-target-id', this.model.get('target_id'));
@@ -271,7 +271,7 @@ pageflow.linkmapPage.AreaItemEmbeddedView = Backbone.Marionette.ItemView.extend(
 
   getColorMapComponent: function() {
     return this.options.colorMap.componentByPermaId(
-      this.model.get('mask_perma_id')
+      this.model.get('color_map_component_id')
     );
   }
 });

--- a/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_masks_preview_embedded_view.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_masks_preview_embedded_view.js
@@ -147,7 +147,7 @@ pageflow.linkmapPage.AreaMasksPreviewEmbeddedView = Backbone.Marionette.ItemView
 
   colorMapComponentIsUsed: function(colorMapComponent) {
     return this.options.areas.any(function(area) {
-      return colorMapComponent.permaId === area.get('mask_perma_id');
+      return colorMapComponent.permaId === area.get('color_map_component_id');
     }, this);
   },
 

--- a/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_outlines_embedded_view.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/views/embedded/area_outlines_embedded_view.js
@@ -28,7 +28,7 @@ pageflow.linkmapPage.AreaOutlineEmbeddedView = Backbone.Marionette.ItemView.exte
     var area = this.options.area;
     var canvas = this.ui.canvas[0];
 
-    var colorMapComponent = this.options.colorMap.componentByPermaId(area.get('mask_perma_id'));
+    var colorMapComponent = this.options.colorMap.componentByPermaId(area.get('color_map_component_id'));
 
     if (colorMapComponent) {
       var attributes = colorMapComponent.areaAttributes();
@@ -73,7 +73,7 @@ pageflow.linkmapPage.AreaOutlineEmbeddedView = Backbone.Marionette.ItemView.exte
 
   drawArea: function(context, area) {
     var canvas = context.canvas;
-    var colorMapComponent = this.options.colorMap.componentByPermaId(area.get('mask_perma_id'));
+    var colorMapComponent = this.options.colorMap.componentByPermaId(area.get('color_map_component_id'));
 
     if (colorMapComponent) {
       colorMapComponent.draw(context, canvas.width);

--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/area_set_mask.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/area_set_mask.js
@@ -1,7 +1,7 @@
 $.fn.linkmapAreaSetMask = function(options) {
   this.each(function() {
     var area = $(this);
-    var colorMapComponent = options.colorMap.componentByPermaId(area.attr('data-mask-perma-id'));
+    var colorMapComponent = options.colorMap.componentByPermaId(area.attr('data-color-map-component-id'));
 
     if (colorMapComponent) {
       area.data('mask', new pageflow.linkmapPage.Mask({

--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/color_map.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/color_map.js
@@ -23,7 +23,7 @@ pageflow.linkmapPage.ColorMap = (function() {
 
     this.areaAttributes = function() {
       return {
-        mask_perma_id: this.permaId,
+        color_map_component_id: this.permaId,
         top: attributes.top / colorMapHeight * 100.0,
         left: attributes.left / colorMapWidth * 100.0,
         height: attributes.height / colorMapHeight * 100.0,

--- a/app/helpers/pageflow/linkmap_page/areas_helper.rb
+++ b/app/helpers/pageflow/linkmap_page/areas_helper.rb
@@ -32,15 +32,15 @@ module Pageflow
       end
 
       def linkmap_area_background_image_div(prefix, attributes, configuration, color_map_file)
-        mask_perma_id = attributes['color_map_component_id'] || attributes['mask_perma_id']
+        color_map_component_id = attributes['color_map_component_id'] || attributes['mask_perma_id']
         if color_map_file &&
-          mask_perma_id.present? &&
-          mask_perma_id.split(':').first.to_i == color_map_file.id
+          color_map_component_id.present? &&
+          color_map_component_id.split(':').first.to_i == color_map_file.id
           background_image_div(configuration,
                                "linkmap_masked_#{prefix}_image",
                                class: "#{prefix}_image",
                                file_type: 'pageflow_linkmap_page_masked_image_files',
-                               style_group: mask_perma_id.split(':').last)
+                               style_group: color_map_component_id.split(':').last)
         else
           background_image_div(configuration,
                                "#{prefix}_image",
@@ -91,8 +91,8 @@ module Pageflow
         end
 
         def data_attributes
-          mask_perma_id = background_type != 'hover_video' &&
-                          (attributes[:color_map_component_id] || attributes[:mask_perma_id])
+          color_map_component_id = background_type != 'hover_video' &&
+                                   (attributes[:color_map_component_id] || attributes[:mask_perma_id])
           audio_file_id = attributes[:target_id]
 
           {
@@ -100,7 +100,7 @@ module Pageflow
             target_id: attributes[:target_id],
             audio_file: audio_file_id.present? ? "#{audio_file_id}.area_#{index}" : nil,
             page_transition: attributes[:page_transition],
-            mask_perma_id: mask_perma_id,
+            color_map_component_id: color_map_component_id,
             width: attributes[:width],
             height: attributes[:height]
           }.delete_if { |key, value| value.blank? }

--- a/app/helpers/pageflow/linkmap_page/areas_helper.rb
+++ b/app/helpers/pageflow/linkmap_page/areas_helper.rb
@@ -32,14 +32,15 @@ module Pageflow
       end
 
       def linkmap_area_background_image_div(prefix, attributes, configuration, color_map_file)
+        mask_perma_id = attributes['color_map_component_id'] || attributes['mask_perma_id']
         if color_map_file &&
-           attributes['mask_perma_id'].present? &&
-           attributes['mask_perma_id'].split(':').first.to_i == color_map_file.id
+          mask_perma_id.present? &&
+          mask_perma_id.split(':').first.to_i == color_map_file.id
           background_image_div(configuration,
                                "linkmap_masked_#{prefix}_image",
                                class: "#{prefix}_image",
                                file_type: 'pageflow_linkmap_page_masked_image_files',
-                               style_group: attributes['mask_perma_id'].split(':').last)
+                               style_group: mask_perma_id.split(':').last)
         else
           background_image_div(configuration,
                                "#{prefix}_image",
@@ -90,7 +91,8 @@ module Pageflow
         end
 
         def data_attributes
-          mask_perma_id = background_type != 'hover_video' && attributes[:mask_perma_id]
+          mask_perma_id = background_type != 'hover_video' &&
+                          (attributes[:color_map_component_id] || attributes[:mask_perma_id])
           audio_file_id = attributes[:target_id]
 
           {

--- a/config/locales/new/color_map_component_id.de.yml
+++ b/config/locales/new/color_map_component_id.de.yml
@@ -1,0 +1,14 @@
+de:
+  activerecord:
+    attributes:
+      pageflow/linkmap_page/area:
+        mask_perma_id: DELETED
+        color_map_component_id: Maske
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/linkmap_page/area:
+          mask_perma_id: DELETED
+          mask_perma_id_disabled: DELETED
+          color_map_component_id: Farbiger Bereich im Maskenbild, der die Form des Hotspots bestimmt.
+          color_map_component_id_disabled: Farbiger Bereich im Maskenbild, der die Form des Hotspots bestimmt. Nur verfügbar, wenn ein Masken-Bild im 'Dateien'-Tab der Hotspot-Seite festgelegt wurde und als Panorama-Typ nicht 'Hover Video' ausgewählt wurde.

--- a/config/locales/new/color_map_component_id.en.yml
+++ b/config/locales/new/color_map_component_id.en.yml
@@ -1,0 +1,14 @@
+en:
+  activerecord:
+    attributes:
+      pageflow/linkmap_page/area:
+        mask_perma_id: DELETED
+        color_map_component_id: Mask
+  pageflow:
+    ui:
+      inline_help:
+        pageflow/linkmap_page/area:
+          mask_perma_id: DELETED
+          mask_perma_id_disabled: DELETED
+          color_map_component_id: Colored area inside mask image which determines the shape of the hotspot.
+          color_map_component_id_disabled: Colored area inside mask image which determines the shape of the hotspot. Only available if a mask image has been selected on the hotspot page's 'Files' tab and the panorama type is not 'Hover video'.

--- a/lib/pageflow/linkmap_page/paperclip_processors/color_mask.rb
+++ b/lib/pageflow/linkmap_page/paperclip_processors/color_mask.rb
@@ -41,7 +41,7 @@ module Pageflow
         end
 
         def with_color_map(&block)
-          PaperclipTempfile.for(color_map_attachment, &block)
+          Pageflow::LinkmapPage::PaperclipTempfile.for(color_map_attachment, &block)
         end
 
         def color_map_attachment

--- a/lib/pageflow/linkmap_page/paperclip_processors/colors.rb
+++ b/lib/pageflow/linkmap_page/paperclip_processors/colors.rb
@@ -163,7 +163,7 @@ module Pageflow
         end
 
         def with_progress(steps:)
-          progress = Progress.new(steps: steps) do |percent|
+          progress = Pageflow::LinkmapPage::Progress.new(steps: steps) do |percent|
             if options[:progress_callback]
               attachment.instance.send(options[:progress_callback], percent)
             end

--- a/lib/tasks/pageflow_linkmap_page_tasks.rake
+++ b/lib/tasks/pageflow_linkmap_page_tasks.rake
@@ -41,7 +41,7 @@ module Pageflow
           color_map_file = color_map_file_for(color_map_image_file, revision)
           page.configuration['linkmap_color_map_file_id'] = color_map_file.id
 
-          hover_image_file = Pageflow::ImageFile.find_by_id(page.configuration['hover_image_id'])
+          hover_image_file = ImageFile.find_by_id(page.configuration['hover_image_id'])
 
           if hover_image_file
             puts "-- Masked image file for hover image file #{hover_image_file.id}"
@@ -100,9 +100,9 @@ module Pageflow
         areas = page.configuration['linkmap_areas'] || []
 
         page.configuration['linkmap_areas'] = areas.map do |area_attributes|
-          old_mask_perma_id = area_attributes['mask_perma_id']
+          mask_perma_id = area_attributes['mask_perma_id']
 
-          if old_mask_perma_id && !area_attributes['old_mask_perma_id']
+          if mask_perma_id && !area_attributes['color_map_component_id']
             sprite_id = page.configuration.fetch('linkmap_masks').fetch('id')
             colors =
               page
@@ -112,11 +112,10 @@ module Pageflow
               .fetch('c')
               .map { |component| component['c'] }
 
-            area_attributes.merge(old_mask_perma_id: old_mask_perma_id,
-                                  mask_perma_id: convert_mask_perma_id(old_mask_perma_id,
-                                                                       colors,
-                                                                       color_map_file,
-                                                                       sprite_id))
+            area_attributes.merge(color_map_component_id: convert_mask_perma_id(mask_perma_id,
+                                                                                colors,
+                                                                                color_map_file,
+                                                                                sprite_id))
           else
             area_attributes
           end

--- a/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
+++ b/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
@@ -113,6 +113,20 @@ module Pageflow
           expect(html).to have_selector('a[data-mask-perma-id="1:aaa"]')
         end
 
+        it 'uses v2 mask perma id if present, preceding mask perma id' do
+          entry = create(:entry)
+          color_map_file_1 = create(:color_map_file)
+          color_map_file_2 = create(:color_map_file)
+          configuration = {
+            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file_2.id}:aaa",
+                                 'mask_perma_id' => "#{color_map_file_1}:aaa"}]
+          }
+
+          html = helper.linkmap_areas_div(entry, configuration)
+
+          expect(html).to have_selector("a[data-mask-perma-id='#{color_map_file_2.id}:aaa']")
+        end
+
         it 'does not set data-mask-perma-id attribute if background type is hover_video' do
           entry = create(:entry)
           configuration = {

--- a/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
+++ b/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
@@ -36,7 +36,7 @@ module Pageflow
           color_map_file = create(:color_map_file)
           masked_image_file = create(:masked_image_file)
           configuration = {
-            'linkmap_areas' => [{'mask_perma_id' => "#{color_map_file.id}:aaa"}],
+            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.id}:aaa"}],
             'hover_image_id' => 5,
             'linkmap_color_map_file_id' => color_map_file.id,
             'linkmap_masked_hover_image_id' => masked_image_file.id
@@ -62,13 +62,13 @@ module Pageflow
           expect(html).to have_selector('a div[class~="image_panorama_5"]')
         end
 
-        it 'does not use masked hover image if area mask perma id references other image' do
+        it 'does not use masked hover image if area color map component id references other image' do
           entry = create(:entry)
           masked_image_file = create(:masked_image_file)
           color_map_file = create(:color_map_file)
           other_id = color_map_file.id + 1
           configuration = {
-            'linkmap_areas' => [{'mask_perma_id' => "#{other_id}:aaa"}],
+            'linkmap_areas' => [{'color_map_component_id' => "#{other_id}:aaa"}],
             'hover_image_id' => 5,
             'linkmap_masked_hover_image_id' => masked_image_file.id
           }
@@ -92,7 +92,7 @@ module Pageflow
           color_map_file = create(:color_map_file)
           masked_image_file = create(:masked_image_file)
           configuration = {
-            'linkmap_areas' => [{'mask_perma_id' => "#{color_map_file.id}:aaa"}],
+            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.id}:aaa"}],
             'hover_image_id' => 5,
             'linkmap_color_map_file_id' => color_map_file.id,
             'linkmap_masked_visited_image_id' => masked_image_file.id
@@ -104,39 +104,51 @@ module Pageflow
           expect(html).to have_selector("a div[class~='#{image_class}']")
         end
 
-        it 'sets data-mask-perma-id attribute if area has mask_perma_id' do
+        it 'sets data-color-map-component-id attribute if area has color_map_component_id' do
           entry = create(:entry)
-          configuration = {'linkmap_areas' => [{'mask_perma_id' => '1:aaa'}]}
+          configuration = {'linkmap_areas' => [{'color_map_component_id' => '1:aaa'}]}
 
           html = helper.linkmap_areas_div(entry, configuration)
 
-          expect(html).to have_selector('a[data-mask-perma-id="1:aaa"]')
+          expect(html).to have_selector('a[data-color-map-component-id="1:aaa"]')
         end
 
-        it 'uses v2 mask perma id if present, preceding mask perma id' do
+        it 'uses color map component id if present, preceding mask perma id' do
           entry = create(:entry)
           color_map_file_1 = create(:color_map_file)
           color_map_file_2 = create(:color_map_file)
           configuration = {
             'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file_2.id}:aaa",
-                                 'mask_perma_id' => "#{color_map_file_1}:aaa"}]
+                                 'mask_perma_id' => "#{color_map_file_1.id}:aaa"}]
           }
 
           html = helper.linkmap_areas_div(entry, configuration)
 
-          expect(html).to have_selector("a[data-mask-perma-id='#{color_map_file_2.id}:aaa']")
+          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file_2.id}:aaa']")
         end
 
-        it 'does not set data-mask-perma-id attribute if background type is hover_video' do
+        it 'uses mask perma id as fallback if present and color map component id is blank' do
+          entry = create(:entry)
+          color_map_file = create(:color_map_file)
+          configuration = {
+            'linkmap_areas' => [{'mask_perma_id' => "#{color_map_file.id}:aaa"}]
+          }
+
+          html = helper.linkmap_areas_div(entry, configuration)
+
+          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file.id}:aaa']")
+        end
+
+        it 'does not set data-color-map-component-id attribute if background type is hover_video' do
           entry = create(:entry)
           configuration = {
-            'linkmap_areas' => [{'mask_perma_id' => '1:aaa'}],
+            'linkmap_areas' => [{'color_map_component_id' => '1:aaa'}],
             'background_type' => 'hover_video'
           }
 
           html = helper.linkmap_areas_div(entry, configuration)
 
-          expect(html).not_to have_selector('a[data-mask-perma-id]')
+          expect(html).not_to have_selector('a[data-color-map-component-id]')
         end
       end
 


### PR DESCRIPTION
Change Rake-Task to not override mask_perma_id but add color_map_component_id to linkmap area configuration.
For all read operations on mask_perma_id color_map_component_id now takes precedence, with mask_perma_id as fallback.
For write operations only color_map_component_id is used.
This way all mask_perma_ids will gradually be converted to color_map_component_ids.

REDMINE-15982