### PR TITLE
Prevent letter boxes in pan zoom

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_pan_zoom.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_pan_zoom.js
@@ -201,9 +201,9 @@
       var areaHeight = area.height();
       var areaPosition = area.position();
 
-      var scale = Math.min(2,
+      var scale = Math.max(1, Math.min(2,
                            this.pageWidth / areaWidth,
-                           this.pageHeight / areaHeight);
+                           this.pageHeight / areaHeight));
 
       var result = {
         scale: scale,


### PR DESCRIPTION
Even for hotspots that are bigger than the viewport, we can never
scale the panorama wrapper with a factor < 1. Since it is resized to
always fit either vertically or horizontally, we would otherwise
create letter or pillar boxes.

REDMINE-16562