### PR TITLE
Always lookup files by revisions usage scope

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/editor/models/page_configuration_mixin.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/models/page_configuration_mixin.js
@@ -3,11 +3,13 @@
     initialize: function(options) {
       this.listenTo(this,
                     'change:linkmap_color_map_image_id',
-                    function(model, imageFileId) {
-                      if (imageFileId) {
+                    function(model, imageFilePermaId) {
+                      if (imageFilePermaId) {
+                        var sourceImageFile = pageflow.imageFiles.getByPermaId(imageFilePermaId);
+
                         this.setReference('linkmap_color_map_file_id',
                                           colorMapFiles().findOrCreateBy({
-                                            source_image_file_id: imageFileId
+                                            source_image_file_id: sourceImageFile.id
                                           }));
                       }
                       else {
@@ -22,8 +24,8 @@
             ' change:linkmap_color_map_file_id' +
             ' change:linkmap_color_map_file_id:ready',
           function() {
-            var colorMapFile = colorMapFiles().get(this.get('linkmap_color_map_file_id'));
-            var imageFile = pageflow.imageFiles.get(this.get(attribute));
+            var colorMapFile = this.getReference('linkmap_color_map_file_id', colorMapFiles());
+            var imageFile = this.getReference(attribute, pageflow.imageFiles);
 
             if (imageFile && colorMapFile && colorMapFile.isReady()) {
               this.setReference('linkmap_masked_' + attribute,
@@ -40,7 +42,7 @@
     },
 
     linkmapReadyColorMapFileId: function() {
-      var colorMapFile = colorMapFiles().get(this.get('linkmap_color_map_file_id'));
+      var colorMapFile = this.getReference('linkmap_color_map_file_id', colorMapFiles());
       return colorMapFile && colorMapFile.isReady() ? colorMapFile.id : null;
     },
 

--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/color_map.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap/color_map.js
@@ -87,8 +87,8 @@ pageflow.linkmapPage.ColorMap = (function() {
     height: 0
   });
 
-  ColorMap.load = function(id) {
-    var colorMapFile = pageflow.entryData.getFile('pageflow_linkmap_page_color_map_files', id);
+  ColorMap.load = function(permaId) {
+    var colorMapFile = pageflow.entryData.getFile('pageflow_linkmap_page_color_map_files', permaId);
 
     if (!colorMapFile) {
       return $.when(ColorMap.empty);

--- a/app/helpers/pageflow/linkmap_page/areas_helper.rb
+++ b/app/helpers/pageflow/linkmap_page/areas_helper.rb
@@ -2,6 +2,7 @@ module Pageflow
   module LinkmapPage
     module AreasHelper
       include BackgroundImageHelper
+      include RevisionFileHelper
 
       def linkmap_content_and_background_css_classes(configuration)
         hide_overlay_boxes =
@@ -16,11 +17,11 @@ module Pageflow
 
       def linkmap_areas_div(entry, configuration)
         color_map_file =
-          ColorMapFile.find_by_id(configuration['linkmap_color_map_file_id'])
+          find_file_in_entry(ColorMapFile, configuration['linkmap_color_map_file_id'])
         masked_hover_image_file =
-          MaskedImageFile.find_by_id(configuration['linkmap_masked_hover_image_id'])
+          find_file_in_entry(MaskedImageFile, configuration['linkmap_masked_hover_image_id'])
         masked_visited_image_file =
-          MaskedImageFile.find_by_id(configuration['linkmap_masked_visited_image_id'])
+          find_file_in_entry(MaskedImageFile, configuration['linkmap_masked_visited_image_id'])
 
         render('pageflow/linkmap_page/areas/div',
                entry: entry,
@@ -37,7 +38,7 @@ module Pageflow
         color_map_component_id = attributes['color_map_component_id'] || attributes['mask_perma_id']
         if color_map_file &&
           color_map_component_id.present? &&
-          color_map_component_id.split(':').first.to_i == color_map_file.id
+          color_map_component_id.split(':').first.to_i == color_map_file.perma_id
           background_image_div(configuration,
                                "linkmap_masked_#{prefix}_image",
                                class: "#{prefix}_image",

--- a/app/views/pageflow/linkmap_page/areas/_div.html.erb
+++ b/app/views/pageflow/linkmap_page/areas/_div.html.erb
@@ -7,8 +7,7 @@
                                             color_map_file) %>
 
       <% if configuration['background_type'] == 'hover_video' &&
-            !Pageflow::ImageFile.find_by_id(configuration['hover_image_id']) %>
-
+            !find_file_in_entry(Pageflow::ImageFile, configuration['hover_image_id']) %>
         <%= background_image_div(configuration,
                                  'panorama_video',
                                  file_type: 'video_file',

--- a/app/views/pageflow/linkmap_page/page.html.erb
+++ b/app/views/pageflow/linkmap_page/page.html.erb
@@ -7,7 +7,7 @@
         <div class="pan_zoom_safe_area_wrapper">
           <div class="panorama_wrapper">
             <% if configuration['background_type'] == 'video' &&
-                  !Pageflow::ImageFile.find_by_id(configuration['panorama_image_id']) %>
+                  !find_file_in_entry(Pageflow::ImageFile, configuration['panorama_image_id']) %>
 
               <%= background_image_div_with_size(configuration,
                                                  'panorama_video',

--- a/pageflow-linkmap-page.gemspec
+++ b/pageflow-linkmap-page.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', '~> 14.x'
+  spec.add_runtime_dependency 'pageflow', '~> 15.x'
   spec.add_runtime_dependency 'pageflow-external-links', '~> 2.x'
 
   spec.add_development_dependency 'bundler', ['>= 1.0', '< 3']

--- a/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
+++ b/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'shared_contexts/usage_agnostic_file_association'
 
 module Pageflow
   module LinkmapPage
@@ -46,29 +47,31 @@ module Pageflow
       end
 
       describe '#linkmap_area_divs' do
+        include_context 'usage agnostic file association'
+
         it 'renders div with attribute name as class' do
-          @entry = PublishedEntry.new(create(:entry, :published))
+          entry = create(:entry)
           configuration = {}
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).to have_selector('div.linkmap_areas')
         end
 
         it 'renders linkmap areas' do
-          @entry = PublishedEntry.new(create(:entry, :published))
+          entry = create(:entry)
           configuration = {'linkmap_areas' => [{}]}
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).to have_selector('div a[href]')
         end
 
         it 'renders hover image inside linkmap areas' do
-          @entry = PublishedEntry.new(create(:entry, :published))
+          entry = create(:entry)
           configuration = {'linkmap_areas' => [{}], 'hover_image_id' => 5}
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).to have_selector("a div[class~='image_panorama_5']")
         end
@@ -76,7 +79,9 @@ module Pageflow
         it 'renders masked hover image inside masked linkmap areas' do
           @entry = PublishedEntry.new(create(:entry, :published))
           color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          entry_has_file(color_map_file)
           masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
+          entry_has_file(masked_image_file)
           configuration = {
             'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.perma_id}:aaa"}],
             'hover_image_id' => 5,
@@ -91,40 +96,40 @@ module Pageflow
         end
 
         it 'only uses masked hover image if area is masked' do
-          @entry = PublishedEntry.new(create(:entry, :published))
-          masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
+          entry = create(:entry)
+          masked_image_file = create(:masked_image_file)
           configuration = {
             'linkmap_areas' => [{}],
             'hover_image_id' => 5,
-            'linkmap_masked_hover_image_id' => masked_image_file.perma_id
+            'linkmap_masked_hover_image_id' => masked_image_file.id
           }
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).to have_selector('a div[class~="image_panorama_5"]')
         end
 
         it 'does not use masked hover image if area color map component id references other image' do
-          @entry = PublishedEntry.new(create(:entry, :published))
-          masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
-          color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
-          other_id = color_map_file.perma_id + 1
+          entry = create(:entry)
+          masked_image_file = create(:masked_image_file)
+          color_map_file = create(:color_map_file)
+          other_id = color_map_file.id + 1
           configuration = {
             'linkmap_areas' => [{'color_map_component_id' => "#{other_id}:aaa"}],
             'hover_image_id' => 5,
-            'linkmap_masked_hover_image_id' => masked_image_file.perma_id
+            'linkmap_masked_hover_image_id' => masked_image_file.id
           }
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).to have_selector('a div[class~="image_panorama_5"]')
         end
 
         it 'renders visited image inside linkmap areas' do
-          @entry = PublishedEntry.new(create(:entry, :published))
+          entry = create(:entry)
           configuration = {'linkmap_areas' => [{}], 'visited_image_id' => 5}
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).to have_selector('a div[class~="image_panorama_5"]')
         end
@@ -132,7 +137,9 @@ module Pageflow
         it 'renders masked visited image inside masked linkmap areas' do
           @entry = PublishedEntry.new(create(:entry, :published))
           color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          entry_has_file(color_map_file)
           masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
+          entry_has_file(masked_image_file)
           configuration = {
             'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.perma_id}:aaa"}],
             'hover_image_id' => 5,
@@ -147,48 +154,48 @@ module Pageflow
         end
 
         it 'sets data-color-map-component-id attribute if area has color_map_component_id' do
-          @entry = PublishedEntry.new(create(:entry, :published))
+          entry = create(:entry)
           configuration = {'linkmap_areas' => [{'color_map_component_id' => '1:aaa'}]}
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).to have_selector('a[data-color-map-component-id="1:aaa"]')
         end
 
         it 'uses color map component id if present, preceding mask perma id' do
-          @entry = PublishedEntry.new(create(:entry, :published))
-          color_map_file_1 = create(:used_file, model: :color_map_file, revision: @entry.revision)
-          color_map_file_2 = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          entry = create(:entry)
+          color_map_file_1 = create(:color_map_file)
+          color_map_file_2 = create(:color_map_file)
           configuration = {
-            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file_2.perma_id}:aaa",
-                                 'mask_perma_id' => "#{color_map_file_1.perma_id}:aaa"}]
+            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file_2.id}:aaa",
+                                 'mask_perma_id' => "#{color_map_file_1.id}:aaa"}]
           }
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
-          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file_2.perma_id}:aaa']")
+          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file_2.id}:aaa']")
         end
 
         it 'uses mask perma id as fallback if present and color map component id is blank' do
-          @entry = PublishedEntry.new(create(:entry, :published))
-          color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          entry = create(:entry)
+          color_map_file = create(:color_map_file)
           configuration = {
-            'linkmap_areas' => [{'mask_perma_id' => "#{color_map_file.perma_id}:aaa"}]
+            'linkmap_areas' => [{'mask_perma_id' => "#{color_map_file.id}:aaa"}]
           }
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
-          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file.perma_id}:aaa']")
+          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file.id}:aaa']")
         end
 
         it 'does not set data-color-map-component-id attribute if background type is hover_video' do
-          @entry = PublishedEntry.new(create(:entry, :published))
+          entry = create(:entry)
           configuration = {
             'linkmap_areas' => [{'color_map_component_id' => '1:aaa'}],
             'background_type' => 'hover_video'
           }
 
-          html = helper.linkmap_areas_div(@entry, configuration)
+          html = helper.linkmap_areas_div(entry, configuration)
 
           expect(html).not_to have_selector('a[data-color-map-component-id]')
         end

--- a/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
+++ b/spec/helpers/pageflow/linkmap_page/areas_helper_spec.rb
@@ -47,148 +47,148 @@ module Pageflow
 
       describe '#linkmap_area_divs' do
         it 'renders div with attribute name as class' do
-          entry = create(:entry)
+          @entry = PublishedEntry.new(create(:entry, :published))
           configuration = {}
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
           expect(html).to have_selector('div.linkmap_areas')
         end
 
         it 'renders linkmap areas' do
-          entry = create(:entry)
+          @entry = PublishedEntry.new(create(:entry, :published))
           configuration = {'linkmap_areas' => [{}]}
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
           expect(html).to have_selector('div a[href]')
         end
 
         it 'renders hover image inside linkmap areas' do
-          entry = create(:entry)
+          @entry = PublishedEntry.new(create(:entry, :published))
           configuration = {'linkmap_areas' => [{}], 'hover_image_id' => 5}
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
-          expect(html).to have_selector('a div[class~="image_panorama_5"]')
+          expect(html).to have_selector("a div[class~='image_panorama_5']")
         end
 
         it 'renders masked hover image inside masked linkmap areas' do
-          entry = create(:entry)
-          color_map_file = create(:color_map_file)
-          masked_image_file = create(:masked_image_file)
+          @entry = PublishedEntry.new(create(:entry, :published))
+          color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
           configuration = {
-            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.id}:aaa"}],
+            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.perma_id}:aaa"}],
             'hover_image_id' => 5,
-            'linkmap_color_map_file_id' => color_map_file.id,
-            'linkmap_masked_hover_image_id' => masked_image_file.id
+            'linkmap_color_map_file_id' => color_map_file.perma_id,
+            'linkmap_masked_hover_image_id' => masked_image_file.perma_id
           }
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
-          image_class = "pageflow_linkmap_page_masked_image_file_aaa_#{masked_image_file.id}"
+          image_class = "pageflow_linkmap_page_masked_image_file_aaa_#{masked_image_file.perma_id}"
           expect(html).to have_selector("a div[class~=#{image_class}]")
         end
 
         it 'only uses masked hover image if area is masked' do
-          entry = create(:entry)
-          masked_image_file = create(:masked_image_file)
+          @entry = PublishedEntry.new(create(:entry, :published))
+          masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
           configuration = {
             'linkmap_areas' => [{}],
             'hover_image_id' => 5,
-            'linkmap_masked_hover_image_id' => masked_image_file.id
+            'linkmap_masked_hover_image_id' => masked_image_file.perma_id
           }
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
           expect(html).to have_selector('a div[class~="image_panorama_5"]')
         end
 
         it 'does not use masked hover image if area color map component id references other image' do
-          entry = create(:entry)
-          masked_image_file = create(:masked_image_file)
-          color_map_file = create(:color_map_file)
-          other_id = color_map_file.id + 1
+          @entry = PublishedEntry.new(create(:entry, :published))
+          masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
+          color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          other_id = color_map_file.perma_id + 1
           configuration = {
             'linkmap_areas' => [{'color_map_component_id' => "#{other_id}:aaa"}],
             'hover_image_id' => 5,
-            'linkmap_masked_hover_image_id' => masked_image_file.id
+            'linkmap_masked_hover_image_id' => masked_image_file.perma_id
           }
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
           expect(html).to have_selector('a div[class~="image_panorama_5"]')
         end
 
         it 'renders visited image inside linkmap areas' do
-          entry = create(:entry)
+          @entry = PublishedEntry.new(create(:entry, :published))
           configuration = {'linkmap_areas' => [{}], 'visited_image_id' => 5}
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
           expect(html).to have_selector('a div[class~="image_panorama_5"]')
         end
 
         it 'renders masked visited image inside masked linkmap areas' do
-          entry = create(:entry)
-          color_map_file = create(:color_map_file)
-          masked_image_file = create(:masked_image_file)
+          @entry = PublishedEntry.new(create(:entry, :published))
+          color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          masked_image_file = create(:used_file, model: :masked_image_file, revision: @entry.revision)
           configuration = {
-            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.id}:aaa"}],
+            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file.perma_id}:aaa"}],
             'hover_image_id' => 5,
-            'linkmap_color_map_file_id' => color_map_file.id,
-            'linkmap_masked_visited_image_id' => masked_image_file.id
+            'linkmap_color_map_file_id' => color_map_file.perma_id,
+            'linkmap_masked_visited_image_id' => masked_image_file.perma_id
           }
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
-          image_class = "pageflow_linkmap_page_masked_image_file_aaa_#{masked_image_file.id}"
+          image_class = "pageflow_linkmap_page_masked_image_file_aaa_#{masked_image_file.perma_id}"
           expect(html).to have_selector("a div[class~='#{image_class}']")
         end
 
         it 'sets data-color-map-component-id attribute if area has color_map_component_id' do
-          entry = create(:entry)
+          @entry = PublishedEntry.new(create(:entry, :published))
           configuration = {'linkmap_areas' => [{'color_map_component_id' => '1:aaa'}]}
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
           expect(html).to have_selector('a[data-color-map-component-id="1:aaa"]')
         end
 
         it 'uses color map component id if present, preceding mask perma id' do
-          entry = create(:entry)
-          color_map_file_1 = create(:color_map_file)
-          color_map_file_2 = create(:color_map_file)
+          @entry = PublishedEntry.new(create(:entry, :published))
+          color_map_file_1 = create(:used_file, model: :color_map_file, revision: @entry.revision)
+          color_map_file_2 = create(:used_file, model: :color_map_file, revision: @entry.revision)
           configuration = {
-            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file_2.id}:aaa",
-                                 'mask_perma_id' => "#{color_map_file_1.id}:aaa"}]
+            'linkmap_areas' => [{'color_map_component_id' => "#{color_map_file_2.perma_id}:aaa",
+                                 'mask_perma_id' => "#{color_map_file_1.perma_id}:aaa"}]
           }
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
-          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file_2.id}:aaa']")
+          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file_2.perma_id}:aaa']")
         end
 
         it 'uses mask perma id as fallback if present and color map component id is blank' do
-          entry = create(:entry)
-          color_map_file = create(:color_map_file)
+          @entry = PublishedEntry.new(create(:entry, :published))
+          color_map_file = create(:used_file, model: :color_map_file, revision: @entry.revision)
           configuration = {
-            'linkmap_areas' => [{'mask_perma_id' => "#{color_map_file.id}:aaa"}]
+            'linkmap_areas' => [{'mask_perma_id' => "#{color_map_file.perma_id}:aaa"}]
           }
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
-          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file.id}:aaa']")
+          expect(html).to have_selector("a[data-color-map-component-id='#{color_map_file.perma_id}:aaa']")
         end
 
         it 'does not set data-color-map-component-id attribute if background type is hover_video' do
-          entry = create(:entry)
+          @entry = PublishedEntry.new(create(:entry, :published))
           configuration = {
             'linkmap_areas' => [{'color_map_component_id' => '1:aaa'}],
             'background_type' => 'hover_video'
           }
 
-          html = helper.linkmap_areas_div(entry, configuration)
+          html = helper.linkmap_areas_div(@entry, configuration)
 
           expect(html).not_to have_selector('a[data-color-map-component-id]')
         end


### PR DESCRIPTION
Migrate all existing find_by_id calls to find_file_in_entry(file_type, file_id) calls.
Use UsedFile-factory in specs to set up file usages.

REDMINE-16809