### PR TITLE
Make processing jobs wait for prerequisites

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/editor/models/page_configuration_mixin.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/models/page_configuration_mixin.js
@@ -19,13 +19,12 @@
         this.listenTo(
           this,
           'change:' + attribute +
-            ' change:linkmap_color_map_file_id' +
-            ' change:linkmap_color_map_file_id:ready',
+            ' change:linkmap_color_map_file_id',
           function() {
             var colorMapFile = colorMapFiles().get(this.get('linkmap_color_map_file_id'));
             var imageFile = pageflow.imageFiles.get(this.get(attribute));
 
-            if (imageFile && colorMapFile && colorMapFile.isReady()) {
+            if (imageFile && colorMapFile) {
               this.setReference('linkmap_masked_' + attribute,
                                 maskedImageFiles().findOrCreateBy({
                                   source_image_file_id: imageFile.id,

--- a/app/jobs/pageflow/linkmap_page/process_source_image_file_job.rb
+++ b/app/jobs/pageflow/linkmap_page/process_source_image_file_job.rb
@@ -6,8 +6,12 @@ module Pageflow
       include StateMachineJob
 
       def perform_with_result(file, _options)
+        return :error if file.prerequisite_files.any?(&:failed?)
+        return :pending unless file.prerequisite_files.all?(&:ready?)
+
         file.attachment = file.source_image_file.attachment
         file.save!
+
         :ok
       end
     end

--- a/app/models/pageflow/linkmap_page/masked_image_file.rb
+++ b/app/models/pageflow/linkmap_page/masked_image_file.rb
@@ -39,6 +39,10 @@ module Pageflow
         color_map_file.present_colors
       end
 
+      def prerequisite_files
+        [color_map_file, source_image_file]
+      end
+
       private
 
       def update_processing_progress(style)

--- a/app/models/pageflow/linkmap_page/processed_image_file.rb
+++ b/app/models/pageflow/linkmap_page/processed_image_file.rb
@@ -23,6 +23,7 @@ module Pageflow
 
         job ProcessSourceImageFileJob do
           on_enter 'processing'
+          result :pending, retry_after: 3.seconds
           result ok: 'processed'
           result error: 'processing_failed'
         end
@@ -52,8 +53,16 @@ module Pageflow
         processed?
       end
 
+      def failed?
+        processing_failed?
+      end
+
       def basename
         'unused'
+      end
+
+      def prerequisite_files
+        [source_image_file]
       end
     end
   end

--- a/pageflow-linkmap-page.gemspec
+++ b/pageflow-linkmap-page.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.1'
 
-  spec.add_runtime_dependency 'pageflow', '~> 14.x'
+  spec.add_runtime_dependency 'pageflow', '~> 14.3.x'
   spec.add_runtime_dependency 'pageflow-external-links', '~> 2.x'
 
   spec.add_development_dependency 'bundler', ['>= 1.0', '< 3']

--- a/pageflow-linkmap-page.gemspec
+++ b/pageflow-linkmap-page.gemspec
@@ -39,4 +39,7 @@ Gem::Specification.new do |spec|
 
   # Semantic versioning rake tasks
   spec.add_development_dependency 'semmy', '~> 1.0'
+
+  # Freeze time in tests
+  spec.add_development_dependency 'timecop', '~> 0.7.1'
 end

--- a/spec/factories/image_file.rb
+++ b/spec/factories/image_file.rb
@@ -2,6 +2,12 @@ FactoryBot.modify do
   fixtures = Pageflow::LinkmapPage::Engine.root.join('spec', 'support', 'fixtures')
 
   factory :image_file do
+    trait :not_yet_uploaded do
+      attachment { nil }
+      file_name { 'image.jpg' }
+      state { 'uploading' }
+    end
+
     trait :red_fixture do
       attachment { File.open(fixtures.join('red.png')) }
     end

--- a/spec/models/pageflow/linkmap_page/color_map_file_spec.rb
+++ b/spec/models/pageflow/linkmap_page/color_map_file_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Pageflow
   module LinkmapPage
-    describe ColorMapFile, inline_resque: true do
+    describe ColorMapFile, perform_jobs: :except_enqued_at do
       let(:red_from_palette) { 'f65b57' }
       let(:green_from_palette) { '69a77b' }
 

--- a/spec/models/pageflow/linkmap_page/color_map_file_spec.rb
+++ b/spec/models/pageflow/linkmap_page/color_map_file_spec.rb
@@ -7,6 +7,26 @@ module Pageflow
       let(:green_from_palette) { '69a77b' }
 
       describe 'process' do
+        it 're-schedules job if source image file is not uploaded yet' do
+          image_file = create(:image_file, :not_yet_uploaded)
+          color_map_file = create(:color_map_file, source_image_file: image_file)
+
+          color_map_file.process
+
+          expect(ProcessSourceImageFileJob)
+            .to have_been_enqueued.at(3.seconds.from_now)
+        end
+
+        it 'fails if source image file failed' do
+          image_file = create(:image_file, :uploading_failed)
+          color_map_file = create(:color_map_file, source_image_file: image_file)
+
+          color_map_file.process
+          color_map_file.reload
+
+          expect(color_map_file).to be_failed
+        end
+
         it 'remaps colors to fixed palette' do
           image_file = create(:image_file, :red_fixture)
           color_map_file = create(:color_map_file, source_image_file: image_file)

--- a/spec/models/pageflow/linkmap_page/masked_image_file_spec.rb
+++ b/spec/models/pageflow/linkmap_page/masked_image_file_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Pageflow
   module LinkmapPage
-    describe MaskedImageFile, inline_resque: true do
+    describe MaskedImageFile, perform_jobs: :except_enqued_at do
       let :color_map_file do
         color_map_image_file = create(:image_file, :color_map_fixture)
 

--- a/spec/support/config/active_job.rb
+++ b/spec/support/config/active_job.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  config.before(:each) do |example|
+    ActiveJob::Base.queue_adapter = :test
+    queue_adapter = ActiveJob::Base.queue_adapter
+
+    queue_adapter.perform_enqueued_jobs = !!example.metadata[:perform_jobs]
+
+    queue_adapter.perform_enqueued_at_jobs = (example.metadata[:perform_jobs] &&
+                                              example.metadata[:perform_jobs] != :except_enqued_at)
+  end
+end

--- a/spec/support/config/resque.rb
+++ b/spec/support/config/resque.rb
@@ -1,9 +1,0 @@
-RSpec.configure do |config|
-  config.before(:each, inline_resque: true) do
-    Resque.inline = true
-  end
-
-  config.after(:each, inline_resque: true) do
-    Resque.inline = false
-  end
-end

--- a/spec/support/config/timecop.rb
+++ b/spec/support/config/timecop.rb
@@ -1,0 +1,11 @@
+require 'timecop'
+
+RSpec.configure do |config|
+  config.before(:each) do
+    Timecop.freeze(Time.local(2013))
+  end
+
+  config.after(:each) do
+    Timecop.return
+  end
+end


### PR DESCRIPTION
Instead of creating color map and masked images only after their
prerequisites (i.e. source image files, color map files of masked
image files) are ready, add pending result to
`ProcessSourceImageFileJob` which causes job to be retried after a few
seconds.

This simplifies editor js code and handles a formerly missing case
that the source image file has not finished uploading yet. (REDMINE-16880)

This will also simplify processing files when importing a revision
(REDMINE-16811) since the order in which files are processed does not
matter.