### PR TITLE
Delete cleanup migration (2.6 Backport)

### DIFF
--- a/db/migrate/20190724114801_delete_orphaned_generated_image_files.rb
+++ b/db/migrate/20190724114801_delete_orphaned_generated_image_files.rb
@@ -1,9 +1,0 @@
-# Deletes orphaned color map files, along with their usages
-# and the associated masked image files along with their usages
-class DeleteOrphanedGeneratedImageFiles < ActiveRecord::Migration[5.2]
-  def up
-    Pageflow::LinkmapPage::ColorMapFile.find_each do |color_map_file|
-      color_map_file.destroy unless color_map_file.source_image_file.present?
-    end
-  end
-end


### PR DESCRIPTION
Backport of #68

Since running the migration added new problems to the complex
handling of linkmap pages, we decided to leave the data as is
and postpone cleaning up generated files with missing source files.

REDMINE-17136
REDMINE-17009