### PR TITLE
Enabled video autoplay for mobile devices.

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/page_type.js
+++ b/app/assets/javascript/pageflow/linkmap_page/page_type.js
@@ -187,14 +187,20 @@ pageflow.pageType.register('linkmap_page', _.extend({
     wrapper
       .attr('data-width', template.data('videoWidth'))
       .attr('data-height', template.data('videoHeight'));
-
-    var videoPlayer = this.videoPlayer = new pageflow.VideoPlayer.Lazy(template, {
+    
+    var options = {
       volumeFading: true,
       fallbackToMutedAutoplay: true,
-
       width: '100%',
       height: '100%'
-    });
+    }
+    if (pageflow.browser.has('mobile platform')) {
+      // to enable autoplay videos on mobile, 'muted' and 'playsinline' needs to be set
+      // video can be unmuted on user interaction
+      options.muted = true;
+      options.playsinline = true;
+    }
+    var videoPlayer = this.videoPlayer = new pageflow.VideoPlayer.Lazy(template, options);
 
     videoPlayer.ready(function() {
       videoPlayer.on('playmuted', function() {
@@ -431,18 +437,25 @@ pageflow.pageType.register('linkmap_page', _.extend({
   },
 
   isVideoEnabled: function(configuration) {
-    return !pageflow.browser.has('mobile platform') &&
-      (configuration.background_type === 'video' || configuration.background_type === 'hover_video');
+    return this.isBackgroundVideoEnabled(configuration) || this.isHoverVideoEnabled(configuration)
   },
 
   isBackgroundVideoEnabled: function(configuration) {
-    return !pageflow.browser.has('mobile platform') &&
-      configuration.background_type === 'video';
+    if (pageflow.browser.has('mobile platform')) {
+      return configuration.background_type === 'video' && configuration.panorama_image_id == undefined
+    }
+    else{
+      return configuration.background_type === 'video'
+    }
   },
 
   isHoverVideoEnabled: function(configuration) {
-    return !pageflow.browser.has('mobile platform') &&
-      configuration.background_type === 'hover_video';
+    if (pageflow.browser.has('mobile platform')) {
+      return configuration.background_type === 'hover_video' && configuration.hover_image_id == undefined
+    }
+    else{
+      return configuration.background_type === 'hover_video'
+    }
   },
 
   updateNavigationMode: function(configuration) {

--- a/app/assets/javascript/pageflow/linkmap_page/widgets/hover_video.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/hover_video.js
@@ -75,6 +75,11 @@
       }, 300);
 
       this.element.removeClass('playing');
+    },
+
+    unmute: function () {
+      var videoPlayer = this.options.video.data('videoPlayer');
+      videoPlayer.muted(false);
     }
   });
 }(jQuery));

--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap.js
@@ -33,6 +33,10 @@
         'click': function(event) {
           var area = this.areaAt(this.positionFromEvent(event));
 
+          if (area.length && area.hasClass('hover_area')){
+            this.options.hoverVideo.unmute();
+          }
+
           if (area.length && area.hasClass('enabled')) {
             area.first().trigger($.Event('linkmapareaclick', {originalEvent: event}));
           }

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -101,9 +101,7 @@ de:
             so viele Hotspots angelegt werden wie gewünscht.
 
             Der Panorama Typ entscheidet darüber, ob die Seite ein
-            Hintergrund-Bild oder Hintergrund-Video zeigt. (Beachte, dass
-            Hintergrund-Videos auf mobilen Geräten nicht abgespielt werden,
-            deshalb wähle ein zusätzliches Panorama-Bild für die mobile Version)
+            Hintergrund-Bild oder Hintergrund-Video zeigt. (Ein zusätzliches Fallback-Image für die mobile Version kann bereitgestellt werden, wenn das Video nicht passt)
 
             Die Hotspot-Seite ermöglicht auch die Nutzung von Panorama-Bildern,
             die größer sind, als der sichtbare Bildschirmbereich. So können Nutzer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
 
             Hotspots can play audio files, link to other pages in a Pageflow or to external websites. You can define as many hotspots as you want.
 
-            Decide if you want to show a background image or a background video. (Keep in mind, that background videos will not be played on mobile devices, therefore use an additional fallback image for the mobile version)
+            Decide if you want to show a background image or a background video. (An additional fallback image for the mobile version can be provided if video does not fit)
 
             The hotspot page type allows to use panoramic images that are wider and taller than the screen-size. It enables users to explore these images by horizontal or vertical scrolling.
 


### PR DESCRIPTION
REDMINE-17335

On mobile devices:
  - Linkmap page background video autoplays without audio 
  - Linkmap page hover video autoplays with audio when user clicks the hover area