### PR TITLE
Use perma id for audio hotspot files

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/models/area.js
@@ -11,7 +11,7 @@ pageflow.linkmapPage.Area = Backbone.Model.extend({
     //     pageflow.xxx.getPolymorphic(this.get('target_type'), this.get('target_id'));
     //
     if (this.get('target_type') === 'audio_file') {
-      return pageflow.audioFiles.get(this.get('target_id'));
+      return pageflow.audioFiles.getByPermaId(this.get('target_id'));
     }
     else if (this.get('target_type') === 'page') {
       return pageflow.pages.getByPermaId(this.get('target_id'));

--- a/app/assets/javascript/pageflow/linkmap_page/editor/models/new_area_file_selection_handler.js
+++ b/app/assets/javascript/pageflow/linkmap_page/editor/models/new_area_file_selection_handler.js
@@ -2,7 +2,7 @@ pageflow.linkmapPage.NewAreaFileSelectionHandler = function(options) {
   var page = pageflow.pages.get(options.id);
 
   this.call = function(file) {
-    page.configuration.linkmapAreas().addAudioFile(file.id);
+    page.configuration.linkmapAreas().addAudioFile(file.get('perma_id'));
     return false;
   };
 


### PR DESCRIPTION
When creating a new area or looking up the target of an area, audio
files were referenced by id instead of perma id. After creating the
area, the file input was therefore empty. Selecting a file via the
file input caused the area list thumbnail to display a missing
indicator instead of the pictogram.

REDMINE-17787