### PR TITLE
Prevent slideshow container from scrolling out of view

### DIFF
--- a/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_pan_zoom.js
+++ b/app/assets/javascript/pageflow/linkmap_page/widgets/linkmap_pan_zoom.js
@@ -81,7 +81,7 @@
       this._ensureScrollerCanNotScroll();
       this._resizePanorama();
       this._transformPanoramaWrapper();
-      this._markAllButCurrentAreaAsDisabled();
+      this._disableAreas();
     },
 
     goToAreaByIndex: function(index) {
@@ -161,13 +161,10 @@
       this.panorama.height(this.panoramaSize.height);
     },
 
-    _markAllButCurrentAreaAsDisabled: function() {
-      var currentArea = this.currentArea;
-
-      this.options.areas().each(function() {
-        var area = $(this);
-        area.toggleClass('enabled', area.is(currentArea));
-      });
+    _disableAreas: function() {
+      // linkmapareaclick event for current area is dispatched above
+      // when user clicks anywhere in the page.
+      this.options.areas().removeClass('enabled');
     },
 
     _transformPanoramaWrapper: function() {


### PR DESCRIPTION
When using the guided hotspot navigation mode, clicking a hotspot that
triggers a page change using a scroll transition causes the slideshow
container (`div.entry.slideshow`) to change its scroll position
(`scrollLeft`/`scrollTop`). In some cases, once the animation finishes
the current page remains partly outside the viewport. Reproducible in
Chrome 89 and Firefox 88.

Clicking the page background (which also activates the current hotspot
in pan/zoom mode) does not cause this behavior. As a workaround, we
therefore keep area pointer events disabled in pan/zoom mode and rely
only on activating hotspots via clicking the background.

The actual root cause remains unknown.

REDMINE-18737